### PR TITLE
Add package versioning step to building-blocktypes workflow

### DIFF
--- a/building-blocktypes/SKILL.md
+++ b/building-blocktypes/SKILL.md
@@ -23,6 +23,10 @@ Block types are the fundamental units of content in Concrete CMS. They allow use
     - Refer to the `working-with-database` skill for the XML format.
 6.  **Register the Block Type**:
     - Install via Dashboard or programmatically in a package `install()` method.
+7.  **Update Package Version** (if the block type belongs to a package):
+    - Increment `$pkgVersion` in the package's `controller.php`.
+    - Update the package's changelog or version history file if one exists.
+    - The version bump is required for the `upgrade()` method to run and install the new block type on existing sites.
 
 ## Reference Documentation
 

--- a/building-blocktypes/SKILL.md
+++ b/building-blocktypes/SKILL.md
@@ -25,7 +25,6 @@ Block types are the fundamental units of content in Concrete CMS. They allow use
     - Install via Dashboard or programmatically in a package `install()` method.
 7.  **Update Package Version** (if the block type belongs to a package):
     - Increment `$pkgVersion` in the package's `controller.php`.
-    - Update the package's changelog or version history file if one exists.
     - The version bump is required for the `upgrade()` method to run and install the new block type on existing sites.
 
 ## Reference Documentation


### PR DESCRIPTION
## Summary

- Adds a step 7 to the building-blocktypes workflow reminding to increment `$pkgVersion` and update the changelog when adding a block type to a package
- This step was documented in building-packages (step 6) but missing from building-blocktypes, which is the skill that gets invoked when creating block types

## Context

When Claude creates a new block type inside a package, the building-blocktypes skill is invoked — not building-packages. Without a versioning reminder in that skill, the package version bump and changelog update get missed, preventing the `upgrade()` method from running on existing sites.